### PR TITLE
Edited the base image for cli-testtol.

### DIFF
--- a/sample-topology/Dockerfile
+++ b/sample-topology/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2
+FROM python:2.7-stretch
 
 WORKDIR /home/topology
  


### PR DESCRIPTION
The previous one was using debian wheezy, which had an issue in one of the
python packages. This was causing problems with ssh connections between
ODL and the cli-testtool.