### PR TITLE
fix unability to build uniconfig-ui because of not update submodule

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -116,8 +116,8 @@ fi
 if [ "$dev_flag" = true ]
 then
     # Update submodules
-    git submodule init
-    git submodule update --recursive --remote
+    #git submodule init
+    git submodule update --init --recursive --remote
 
     cd conductor
     echo 'git.root=../../' > gradle.properties


### PR DESCRIPTION
FM-399
Was added new submodule in folder
https://github.com/FRINXio/frinx-uniconfig-ui/tree/master/client/src/components/workflows
was not properly initialized and updated which caused
jenkins job unable to build docker images

Signed-off-by: Stanislav Chlebec <schlebec@frinx.io>