### PR TITLE
fix building of frinx/fm-dynomite docker image

### DIFF
--- a/dynomite/Dockerfile
+++ b/dynomite/Dockerfile
@@ -2,7 +2,7 @@
 # cd FRINX-machine
 # docker build -f dynomite/Dockerfile -t frinx/dynomite:latest .
 
-FROM ubuntu 
+FROM ubuntu:18.04
  
 
 # Update the repository sources list and Install package Build Essential 


### PR DESCRIPTION
building from scratch downloaded ubuntu docker image
with ubuntu focal distribution
which caused error
Package 'tcl8.5' has no installation candidate
Service 'dynomite' failed to build

Fixed by stating the exact version of ubuntu:18.04

Signed-off-by: Stanislav Chlebec <schlebec@frinx.io>