### PR TITLE
Added restart policy for portainer

### DIFF
--- a/docker-compose.bridge.yml
+++ b/docker-compose.bridge.yml
@@ -196,6 +196,7 @@ services:
       dockerfile: ./portainer/Dockerfile
     image: frinx/fm-portainer:${RELEASE_VERSION}
     container_name: portainer
+    restart: always
     logging:
       driver: "json-file"
       options:

--- a/docker-compose.host.yml
+++ b/docker-compose.host.yml
@@ -241,6 +241,7 @@ services:
       dockerfile: ./portainer/Dockerfile
     image: frinx/fm-portainer:${RELEASE_VERSION}
     container_name: portainer
+    restart: always
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
portainer is shut down after 5 min if admin password
is not set. Restart the portainer so user can create
password anytime.

Signed-off-by: Martin Sunal <msunal@frinx.io>