### PR TITLE
bumped uniflow-api to 1.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 /composefiles/uniconfig/**
 !/composefiles/uniconfig/README
+/config/uniconfig/frinx/uniconfig/cache/**

--- a/composefiles/swarm-uniflow.yml
+++ b/composefiles/swarm-uniflow.yml
@@ -195,7 +195,7 @@ services:
       start_period: 20s
 
   uniflow-api:
-    image: frinx/uniflow-api:1.0.0
+    image: frinx/uniflow-api:1.0.1
     environment:
       - CONDUCTOR_HOST=conductor-server:8080
     logging:


### PR DESCRIPTION
- bumped version
- added uniconfig cache to .gitignore

Signed-off-by: Martin Sunal <msunal@frinx.io>