### PR TITLE
Fix dashboard

### DIFF
--- a/composefiles/swarm-uniflow.yml
+++ b/composefiles/swarm-uniflow.yml
@@ -90,18 +90,12 @@ services:
       replicas: 1
 
   dashboard:
-    image: frinx/frinx-dashboard:latest
+    image: frinx/frinx-dashboard:1.0.1
     logging:
       driver: "json-file"
       options:
         max-file: "3"
         max-size: "10m"
-    healthcheck:
-      test: curl --silent -o /dev/null  --write-out 'HTTPSTATUS:%{http_code}\n' -X GET 'http://127.0.0.1:5001' || exit 1
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
 
   postgresql:
     image: postgres:12.2


### PR DESCRIPTION
Reverts dashboard 1.0.1.
Latest had some additional changes which would require some effort to make work with current FM deployment.
1.0.1 did not have dependency for health check, removed it as well.
As it is going to be replaced soon a chose this solutions as opposed to altering the dashboard.