### PR TITLE
use http as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Each service will show as 'REPLICAS 1/1' when the service is up (it may take sev
 
 UniFlow dashboard is accessible via web browser by visiting:
 ```sh
-https://<IP_of_node_running_FM>
+http://<IP_of_node_running_FM>
 ```
 In some cases the self signed certificate of the FM dashboard creates an NET_ERR_CERT_INVALID error message in your browser. Follow [these](https://stackoverflow.com/questions/35274659/does-using-badidea-or-thisisunsafe-to-bypass-a-chrome-certificate-hsts-error) steps to proceed.
 

--- a/startup.sh
+++ b/startup.sh
@@ -24,8 +24,8 @@ function help {
   usage
     echo -e "OPTIONS:"
     echo -e " -h | --help                    Display this message and exit"
-    echo -e "[--no-micros --http]                   Do not start micros container/ Deploy in http mode"
-    echo -e " --uniflow-only [--no-micros --http]   Deploy UniFlow services locally"
+    echo -e "[--no-micros --https]                   Do not start micros container/ Deploy in https mode"
+    echo -e " --uniflow-only [--no-micros --https]   Deploy UniFlow services locally"
     echo -e " --deploy-uniconfig <hostname>  Deploy UniConfig services on swarm worker node"
     echo -e ""
   example
@@ -38,9 +38,9 @@ function argumentsCheck {
   startupType="local"
   nodeName=$(hostname)
   noMicros="false"
-  API_GATEWAY_HTTPS="true"
-  API_GATEWAY_HEALTHCHECK_PROTOCOL="https"
-  API_GATEWAY_PORT=443
+  API_GATEWAY_HTTPS="false"
+  API_GATEWAY_HEALTHCHECK_PROTOCOL="http"
+  API_GATEWAY_PORT=80
 
 
   case $1 in
@@ -80,10 +80,10 @@ function parseAdditionalArgs {
         noMicros="true"
       ;;
      
-     --http)
-       API_GATEWAY_HTTPS="false"
-       API_GATEWAY_HEALTHCHECK_PROTOCOL="http"
-       API_GATEWAY_PORT=80
+     --https)
+       API_GATEWAY_HTTPS="true"
+       API_GATEWAY_HEALTHCHECK_PROTOCOL="https"
+       API_GATEWAY_PORT=443
       ;;
 
       *)


### PR DESCRIPTION
Some users had problem with selfsigned certs when https was default.
HTTP is as default now and param --https can be used in production.

Signed-off-by: Martin Sunal <msunal@frinx.io>