### PR TITLE
Fixed publishing of API-GW port

### DIFF
--- a/composefiles/swarm-uniflow.yml
+++ b/composefiles/swarm-uniflow.yml
@@ -24,7 +24,11 @@ services:
         max-file: "3"
         max-size: "10m"
     ports:
-      - ${API_GATEWAY_PORT}:5000
+      - target: 5000
+        published: ${API_GATEWAY_PORT}
+        mode: host # This makes host to listen on 0.0.0.0:${API_GATEWAY_PORT} 
+                   # It is the same as you would expect when publishing a port when not running in swarm mode. 
+                   # It is NOT host networking in plain docker.
     deploy:
       placement:
         constraints:


### PR DESCRIPTION
Publish port on the host instead of routing mesh.
API-GW was not reachable on host IP via routing mesh in some case,
which might be caused by specific docker version Docker version 19.03.13, build 4484c46d9d.
It would need more investigation but we just need to publish port on host for now.

Signed-off-by: Martin Sunal <msunal@frinx.io>