### PR TITLE
Update exposed endpoints on kraken

### DIFF
--- a/config/krakend/settings/workflow_proxy_settings.json
+++ b/config/krakend/settings/workflow_proxy_settings.json
@@ -46,14 +46,24 @@
             "url_pattern": "/metadata/workflow/{name}"
         },
         {
-            "endpoint": "/api/uniflow/metadata/workflow/{a}/{b}",
+            "endpoint": "/api/uniflow/metadata/workflow/{name}/{version}",
             "method": "DELETE",
-            "url_pattern": "/metadata/workflow/{a}/{b}"
+            "url_pattern": "/metadata/workflow/{name}/{version}"
         },
         {
             "endpoint": "/api/uniflow/workflow/{a}",
             "method": "GET",
             "url_pattern": "/workflow/{a}"
+        },
+        {
+            "endpoint": "/api/uniflow/workflow/{a}",
+            "method": "DELETE",
+            "url_pattern": "/workflow/{a}"
+        },
+        {
+            "endpoint": "/api/uniflow/workflow/{a}/{b}",
+            "method": "DELETE",
+            "url_pattern": "/workflow/{a}/{b}"
         },
         {
             "endpoint": "/api/uniflow/workflow",
@@ -101,14 +111,9 @@
             "url_pattern": "/schedule"
         },
         {
-            "endpoint": "/api/uniflow/schedule/{a}",
+            "endpoint": "/api/uniflow/schedule/{name}",
             "method": "GET",
-            "url_pattern": "/schedule/{a}"
-        },
-        {
-            "endpoint": "/api/uniflow/schedule/{a}/workflow",
-            "method": "GET",
-            "url_pattern": "/schedule/{a}/workflow"
+            "url_pattern": "/schedule/{name}"
         },
         {
             "endpoint": "/api/uniflow/schedule/{name}",
@@ -129,11 +134,6 @@
             "endpoint": "/api/uniflow/editableworkflows",
             "method": "GET",
             "url_pattern": "/editableworkflows"
-        },
-        {
-            "endpoint": "/api/uniflow/workflow/{a}/{b}",
-            "method": "DELETE",
-            "url_pattern": "/workflow/{a}/{b}"
         },
         {
             "endpoint": "/api/uniflow/workflow/bulk/pause",

--- a/config/krakend/settings/workflow_proxy_settings_deprecated.json
+++ b/config/krakend/settings/workflow_proxy_settings_deprecated.json
@@ -6,11 +6,6 @@
             "url_pattern": "/metadata"
         },
         {
-            "endpoint": "/api/uniflow/metadata/workflow/{name}/{version}",
-            "method": "GET",
-            "url_pattern": "/metadata/workflow/{name}/{version}"
-        },
-        {
             "endpoint": "/api/uniflow/bulk/terminate",
             "method": "DELETE",
             "url_pattern": "/bulk/terminate"
@@ -46,9 +41,9 @@
             "url_pattern": "/executions"
         },
         {
-            "endpoint": "/api/uniflow/workflow/{a}",
-            "method": "DELETE",
-            "url_pattern": "/workflow/{a}"
+            "endpoint": "/api/uniflow/schedule/{name}/{b}",
+            "method": "GET",
+            "url_pattern": "/schedule/{name}/{b}"
         }
     ]
 }

--- a/config/krakend/settings/workflow_proxy_settings_deprecated.json
+++ b/config/krakend/settings/workflow_proxy_settings_deprecated.json
@@ -6,6 +6,11 @@
             "url_pattern": "/metadata"
         },
         {
+            "endpoint": "/api/uniflow/metadata/workflow/{name}/{version}",
+            "method": "GET",
+            "url_pattern": "/metadata/workflow/{name}/{version}"
+        },
+        {
             "endpoint": "/api/uniflow/bulk/terminate",
             "method": "DELETE",
             "url_pattern": "/bulk/terminate"


### PR DESCRIPTION
Moved closer to desired 1.5.
All endpoints except api/uniflow/workflow/{workflowId}/remove should be there. Unfortunately it is in conflict with
the other endpoints in desired state. 
My proposal for fix: api/uniflow/workflow/remove/{workflowId}