### PR TITLE
Increase max db_pool_size to 300 for uniconfig db

### DIFF
--- a/composefiles/swarm-uniconfig.yml
+++ b/composefiles/swarm-uniconfig.yml
@@ -142,6 +142,7 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+    command: postgres -N 300
     ulimits:
       nofile:
         soft: ${UP_ULIMIT_NOFILE_SOFT}

--- a/config/uniconfig/frinx/uniconfig/config/lighty-uniconfig-config.json
+++ b/config/uniconfig/frinx/uniconfig/config/lighty-uniconfig-config.json
@@ -147,7 +147,7 @@
             // initial size of the connection pool (pre-initialized connections)
             "initialDbPoolSize": 5,
             // maximum size of the connection pool, before creation of next connections are blocked
-            "maxDbPoolSize": 100,
+            "maxDbPoolSize": 300,
             // maximum number of idle connections before next idle connections are cleaned
             "maxIdleConnections": 5,
             // maximum wait time for obtaining of a new connection before fetch request is dropped [milliseconds]


### PR DESCRIPTION
increase max db pool size to 300 for uniconfig db