### PR TITLE
Increase of trasholds for Policy filter XR worklow

### DIFF
--- a/config/conductor/config.properties
+++ b/config/conductor/config.properties
@@ -41,8 +41,8 @@ conductor.app.workflowInputPayloadSizeThreshold=25
 conductor.app.workflowOutputPayloadSizeThreshold=25
 conductor.app.maxWorkflowInputPayloadSizeThreshold=1024000
 conductor.app.maxWorkflowOutputPayloadSizeThreshold=1024000
-conductor.app.taskInputPayloadSizeThreshold=25
-conductor.app.taskOutputPayloadSizeThreshold=25
+conductor.app.taskInputPayloadSizeThreshold=85
+conductor.app.taskOutputPayloadSizeThreshold=85
 conductor.app.maxTaskInputPayloadSizeThreshold=1024000
 conductor.app.maxTaskOutputPayloadSizeThreshold=1024000
 


### PR DESCRIPTION
Policy filter XR are crashing because conductor.app.taskInputPayloadSizeThreshold & conductor.app.taskOutputPayloadSizeThreshold limits was too low (25). In these case output from UNICONFIG_read_structured_device_dataRefName_8xGO moves to external storage and the following task jsonJQ_oOEn can't read from this memory - his input is empty. If we increase limits to 85 (with small reserve - 83 is enough) and we will make small change in uri of the Policy filter XR workflow, it will be work fine without crash.