### PR TITLE
Update networking and port configuration

### DIFF
--- a/composefiles/support/swarm-monitoring.yml
+++ b/composefiles/support/swarm-monitoring.yml
@@ -3,7 +3,7 @@ version: "3.7"
 x-logging: &logging_loki
     driver: loki
     options:
-      loki-url: "http://${MANAGER_IP_ADDR}:3100/loki/api/v1/push"
+      loki-url: "http://127.0.0.1:3100/loki/api/v1/push"
       max-file: "3"
       max-size: "10m"
       mode: non-blocking
@@ -75,7 +75,9 @@ services:
           cpus: ${MG_RES_LIMIT_CPUS}
           memory: ${MG_RES_LIMIT_MEM}
     ports:
-    - 3000:3000
+      - target: 3000
+        published: 3000
+        mode: host
 
   loki:
     image: grafana/loki:2.2.1
@@ -119,8 +121,9 @@ services:
           cpus: ${ML_RES_LIMIT_CPUS}
           memory: ${ML_RES_LIMIT_MEM}
     ports:
-    - 3100:3100
-
+      - target: 3100
+        published: 3100
+        
   influxdb:
     image: influxdb:2.1
     logging: *logging_loki
@@ -258,3 +261,4 @@ volumes:
 networks:
     default:
       name: frinx-machine
+      driver: overlay

--- a/composefiles/swarm-uniconfig.yml
+++ b/composefiles/swarm-uniconfig.yml
@@ -8,7 +8,7 @@ version: "3.7"
 x-logging: &logging_loki
     driver: loki
     options:
-      loki-url: "http://${MANAGER_IP_ADDR}:3100/loki/api/v1/push"
+      loki-url: "http://127.0.0.1:3100/loki/api/v1/push"
       max-file: "3"
       max-size: "10m"
       mode: non-blocking
@@ -308,6 +308,7 @@ volumes:
 networks:
   default:
     name: frinx-machine
+    driver: overlay
 
   uniconfig-network:
     name: uniconfig-network

--- a/composefiles/swarm-unistore.yml
+++ b/composefiles/swarm-unistore.yml
@@ -8,7 +8,7 @@ version: "3.7"
 x-logging: &logging_loki
     driver: loki
     options:
-      loki-url: "http://${MANAGER_IP_ADDR}:3100/loki/api/v1/push"
+      loki-url: "http://127.0.0.1:3100/loki/api/v1/push"
       max-file: "3"
       max-size: "10m"
       mode: non-blocking
@@ -181,3 +181,4 @@ secrets:
 networks:
     default:
       name: frinx-machine
+      driver: overlay

--- a/composefiles/swarm-workflow-manager.yml
+++ b/composefiles/swarm-workflow-manager.yml
@@ -4,7 +4,7 @@ version: "3.7"
 x-logging: &logging_loki
     driver: loki
     options:
-      loki-url: "http://${MANAGER_IP_ADDR}:3100/loki/api/v1/push"
+      loki-url: "http://127.0.0.1:3100/loki/api/v1/push"
       max-file: "3"
       max-size: "10m"
       mode: non-blocking
@@ -571,3 +571,4 @@ volumes:
 networks:
   default:
     name: frinx-machine
+    driver: overlay

--- a/startup.sh
+++ b/startup.sh
@@ -242,7 +242,6 @@ function startContainers {
 
   setUniconfigZoneEnv
   setNodeIdLocalDeploy
-  setManagerIpAddrEnv
   
   case $startupType in
       workflow-manager)
@@ -449,12 +448,6 @@ function setProxyEnv {
   setVariableFile "${stackProxyFile}"
   echo -e "${INFO} Proxy settings enabled!"
   echo -e "${INFO} http: ${HTTP_PROXY:-${WARNING}NaN}, https: ${HTTPS_PROXY:-${WARNING}NaN}, no: ${NO_PROXY:-${WARNING}NaN}"
-}
-
-
-function setManagerIpAddrEnv {
-  MANAGER_IP_ADDR=$(hostname -I | cut -d ' ' -f 1)
-  export MANAGER_IP_ADDR
 }
 
 


### PR DESCRIPTION
 - Grafana port exposed with host mode to bypass the swarm routing mesh
 - Loki plugin forwarder to use swarm routing mesh from swarm worker nodes